### PR TITLE
Add convenience properties to check for IDE

### DIFF
--- a/src/Commands/Commands.csproj
+++ b/src/Commands/Commands.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <AssemblyName>Devlooped.SponsorLink.Commands</AssemblyName>
-    <RootNamespace>Devlooped.SponsorLink</RootNamespace>
+    <AssemblyName>Devlooped.Sponsors.Commands</AssemblyName>
+    <RootNamespace>Devlooped.Sponsors</RootNamespace>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <!-- Makes it easier to write code that can be simply sync'ed -->
     <ImplicitUsings>disable</ImplicitUsings>

--- a/src/Commands/SponsorLink.cs
+++ b/src/Commands/SponsorLink.cs
@@ -4,7 +4,6 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
 using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
 
@@ -24,6 +23,26 @@ public static partial class SponsorLink
         PublicKey = CreateRSAFromPublicKey(Convert.FromBase64String(Constants.PublicKey));
         Status = Manifest.TryRead(out manifest);
     }
+
+    /// <summary>
+    /// Whether the current process is running in an IDE, either 
+    /// <see cref="IsVisualStudio"/> or <see cref="IsRider"/>.
+    /// </summary>
+    public static bool IsEditor => IsVisualStudio || IsRider;
+
+    /// <summary>
+    /// Whether the current process is running as part of an active Visual Studio instance.
+    /// </summary>
+    public static bool IsVisualStudio =>
+        Environment.GetEnvironmentVariable("ServiceHubLogSessionKey") != null ||
+        Environment.GetEnvironmentVariable("VSAPPIDNAME") != null;
+
+    /// <summary>
+    /// Whether the current process is running as part of an active Rider instance.
+    /// </summary>
+    public static bool IsRider =>
+        Environment.GetEnvironmentVariable("RESHARPER_FUS_SESSION") != null ||
+        Environment.GetEnvironmentVariable("IDEA_INITIAL_DIRECTORY") != null;
 
     /// <summary>
     /// The public key used to validate manifests signed with the default private key.


### PR DESCRIPTION
SponsorLink can typically be checked within an IDE to provide enhanced editing experience to sponsors. As such, checking whether certain logic is running in an editor is important.

For now, we provide IsEditor by detecting IsVisualStudio and IsRider. Other editor might be added in the future if we can find a way to detect them.