### PR TITLE
Consider contributed sponsorable repos as sponsored

### DIFF
--- a/src/Commands/Commands.csproj
+++ b/src/Commands/Commands.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Auth0.AuthenticationApi" Version="7.22.2" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.32.1" />
     <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="all" Condition="$(TargetFramework) == 'netstandard2.0'" />
+    <PackageReference Include="SharpYaml" Version="2.1.0" />
     <PackageReference Include="Spectre.Console.Analyzer" Version="0.47.0" PrivateAssets="all" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
     <PackageReference Include="Spectre.Console.Json" Version="0.47.0" />

--- a/src/Commands/GraphQL.cs
+++ b/src/Commands/GraphQL.cs
@@ -1,0 +1,93 @@
+﻿namespace Devlooped.Sponsors;
+
+/// <summary>
+/// Centralizes queries used to retrieve data from the GitHub GraphQL API.
+/// </summary>
+static class GraphQL
+{
+    public const string UserSponsorships =
+        """
+        query { 
+          viewer { 
+            sponsorshipsAsSponsor(activeOnly: true, first: 100, orderBy: {field: CREATED_AT, direction: ASC}) {
+              nodes {
+                 sponsorable {
+                   ... on Organization {
+                     login
+                   }
+                   ... on User {
+                     login
+                   }
+                 }        
+              }
+            }
+          }
+        }
+        """;
+
+    public const string UserOrganizations =
+        """
+        query { 
+            viewer { 
+            organizations(first: 100) {
+                nodes {
+                login
+                isVerified
+                email
+                websiteUrl
+                }
+            }
+            }
+        }
+        """;
+
+    public const string OrganizationSponsorships =
+        $$"""
+        query($login: String!) { 
+          organization(login: $login) { 
+            sponsorshipsAsSponsor(activeOnly: true, first: 100) {
+              nodes {
+                 sponsorable {
+                   ... on Organization {
+                     login
+                   }
+                   ... on User {
+                     login
+                   }
+                 }        
+              }
+            }
+          }
+        }
+        """;
+
+    // Alternative query, but includes private repositories too, not very useful.
+    // It's highly unlikely that private repositories will be sponsorable anyway.
+    /*
+        query {
+            viewer {
+            contributionsCollection {
+                commitContributionsByRepository(maxRepositories: 100) {
+                repository {
+                    nameWithOwner
+                }
+                }
+            }
+            }
+        }    
+    */
+
+    public const string UserContributions =
+        """
+        query {
+          viewer {
+            repositoriesContributedTo(first: 100, contributionTypes: [COMMIT]) {
+              nodes {
+                nameWithOwner
+              }
+            }
+          }
+        }
+        """;
+
+}


### PR DESCRIPTION
It's only fair to consider sponsorable repos you contributed actively to (via commits, i.e. through a merged PR) as a contributor to its sponsorable accounts, as defined either in the repo `FUNDING.yml` or the org-wide community file for the same.