### PR TITLE
Use native API from lowest possible TF

### DIFF
--- a/src/Commands/SponsorLink.cs
+++ b/src/Commands/SponsorLink.cs
@@ -47,7 +47,7 @@ public static partial class SponsorLink
     public static bool? Contains(string user, string sponsorable)
         => manifest?.Contains(user, sponsorable);
 
-#if NET6_0_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_1_OR_GREATER
     static RSA CreateRSAFromPublicKey(byte[] publicKey)
     {
         var rsa = RSA.Create();


### PR DESCRIPTION
RSA.ImportRSAPublicKey is actually available from NS2.1/.NETCore3.1+ actually, not just NET6+.